### PR TITLE
Use 'config' instead 'device' to specify device type

### DIFF
--- a/example/mnist_mlp_auto_shape_inference.py
+++ b/example/mnist_mlp_auto_shape_inference.py
@@ -18,7 +18,7 @@ label = tf.placeholder(tf.float32)
 cross_entropy = tf.nn.mean_sparse_softmax_cross_entropy_with_logits(fc2, label)
 train_step = tf.train.GradientDescentOptimizer(0.5).minimize(cross_entropy)
 
-sess = tf.Session(device='gpu')
+sess = tf.Session(config='gpu')
 
 # Automatic variable shape inference API, infers the shape and initialize the weights.
 known_shape = {x: [100, 28 * 28], label: [100]}


### PR DESCRIPTION
This fixes the error below for mnist_mlp_auto_shape_inference.py

Traceback (most recent call last):
  File "example/mnist_mlp_auto_shape_inference.py", line 21, in <module>
    sess = tf.Session(device='gpu')
TypeError: __init__() got an unexpected keyword argument 'device'